### PR TITLE
Hdw.dat.hok tdiff update

### DIFF
--- a/hdw.dat.hok
+++ b/hdw.dat.hok
@@ -8,5 +8,5 @@
 #
 #                              GEOGRAPHIC              BORE-   OFF  BEAM V  |--------- interferometer ---------| |--- RX ---| RNG MX
 #       YYYYMMDD HH:MM:SS     LAT       LON      ALT   SIGHT   SET  SEP  SG PS  TDIFF  TDIFF    X      Y     Z    RXRIS  ATTN     BM
-  40  1 20061101 00:00:00  43.5319   143.6146   480.0   30.0  0.00  3.24  1  1  0.000  0.000    0.0 -100.0   2.9  100.0  10 7 110 16
+  40  1 20061101 00:00:00  43.5319   143.6146   480.0   30.0  0.00  3.24  1  1 -0.050  0.000    0.0 -100.0   2.9  100.0  10 7 110 16
 # EOF


### PR DESCRIPTION
I received this update to the `hdw.dat.hok` from Nozomu Nishitani during the RST 5.1.1 release that should be made available in the coming days.  The change to the tdiff value comes after data analysis through a few different methods.